### PR TITLE
WIP: Adding code to create bias_per_residue json

### DIFF
--- a/mpnnutils.py
+++ b/mpnnutils.py
@@ -158,6 +158,7 @@ def parse_PDB(path_to_pdb, input_chain_list=None, ca_only=False):
         concat_O = []
         concat_mask = []
         coords_dict = {}
+        chain_labels = {}
         for letter in chain_alphabet:
             if ca_only:
                 sidechain_atoms = ['CA']
@@ -167,6 +168,7 @@ def parse_PDB(path_to_pdb, input_chain_list=None, ca_only=False):
             if type(xyz) != str:
                 concat_seq += seq[0]
                 my_dict['seq_chain_'+letter]=seq[0]
+                chain_labels[letter] = seq[0]
                 coords_dict_chain = {}
                 if ca_only:
                     coords_dict_chain['CA_chain_'+letter]=xyz.tolist()
@@ -181,6 +183,7 @@ def parse_PDB(path_to_pdb, input_chain_list=None, ca_only=False):
         my_dict['name']=biounit[(fi+1):-4]
         my_dict['num_of_chains'] = s
         my_dict['seq'] = concat_seq
+        my_dict['chain_labels'] = chain_labels
         if s <= len(chain_alphabet):
             pdb_dict_list.append(my_dict)
             c+=1


### PR DESCRIPTION
* Added code to parse (my version of) `bias_by_residue_jsonl`.

* This code will allow ProteinMPNN to use a custom amino acid bias per position in the residue. For example, residue 11 could have higher weights for "A","K", and "M" whereas residue 103 can weight "F", "R", "T", and "S" more heavily.

* This is not the correct format for the `bias_by_res_jsonl`. Instead, it's easier to pass in just a JSON that has a dictionary where the first level is the chain ID, then the next level are residue positions, and then the next is a list of the amino acid at that residue and the values are the weights for that amino acid at that residue. 

For example, 

        {
            "A": {
                "7": {
                    "D": 0,
                    "E": 45,
                    "I": 3,
                    "N": 14,
                    "R": 2,
                    "S": 30,
                    "Y": 17
                },
                "24": {
                    "A": 0,
                    "E": 40,
                    "G": 5,
                    "P": 21,
                    "R": 2,
                    "S": 25,
                    "W": 7,
                    "Y": 15
                },
                "83": {
                    "E": 40,
                    "K": 65,
                    "Q": 25,
                    "R": 8,
                    "T": 2
                },
            },
            "D": {
                "34": {
                    "D": 3,
                    "K": 1,
                    "L": 22,
                    "S": 1,
                    "W": 0
                },
                "62": {
                    "G": 2,
                    "K": 1,
                    "L": 22,
                    "R": 78,
                    "S": 2
                },
            }
        }
        
        """
* The code will use the JSON to create a new JSON that is in the expected format for `bias_by_res_jsonl`. Each chain has a 2D NumPy array of size `sequence_length` by 21 where 21 is the number of amino acids (20) plus the "X" spacer amino acid. The columns represent the residue at that position in the  protein sequence. The row is the likelihood that the amino acid is picked by ProteinMPNN in the new candidate sequences. I normalized the likelihoods to sum to 1 so that they would be a probability distribution. However, I don't think ProteinMPNN requires that.